### PR TITLE
Implements SaddlePoints exercise

### DIFF
--- a/saddle-points/.exercism/metadata.json
+++ b/saddle-points/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"saddle-points","id":"37c69bfddf724a17b9e333af07a7e6f5","url":"https://exercism.io/my/solutions/37c69bfddf724a17b9e333af07a7e6f5","handle":"de-farias","is_requester":true,"auto_approve":false}

--- a/saddle-points/README.md
+++ b/saddle-points/README.md
@@ -1,0 +1,59 @@
+# Saddle Points
+
+Detect saddle points in a matrix.
+
+So say you have a matrix like so:
+
+```text
+    0  1  2
+  |---------
+0 | 9  8  7
+1 | 5  3  2     <--- saddle point at (1,0)
+2 | 6  6  7
+```
+
+It has a saddle point at (1, 0).
+
+It's called a "saddle point" because it is greater than or equal to
+every element in its row and less than or equal to every element in
+its column.
+
+A matrix may have zero or more saddle points.
+
+Your code should be able to provide the (possibly empty) list of all the
+saddle points for any given matrix.
+
+The matrix can have a different number of rows and columns (Non square).
+
+Note that you may find other definitions of matrix saddle points online,
+but the tests for this exercise follow the above unambiguous definition.
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby saddle_points_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride saddle_points_test.rb
+
+
+## Source
+
+J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/saddle-points/saddle_points.rb
+++ b/saddle-points/saddle_points.rb
@@ -1,0 +1,47 @@
+require 'colorize'
+
+class Matrix
+  attr_reader :rows
+
+  def initialize(schema)
+    @rows = schema.split("\n")
+                  .map { |row| row.split(' ').map(&:to_i) }
+  end
+
+  def columns
+    rows.transpose
+  end
+
+  def saddle_points
+    saddle_points = []
+
+    elements_count.times do |idx|
+      row_idx, col_idx = idx.divmod(rows[0].length)
+
+      next unless largest_in_row?(rows[row_idx], col_idx) &&
+                  smallest_in_column?(columns[col_idx], row_idx)
+
+      saddle_points << [row_idx, col_idx]
+    end
+
+    saddle_points
+  end
+
+  private
+
+  def elements_count
+    rows.sum(&:length)
+  end
+
+  def largest_in_row?(row, idx)
+    row.each_with_index.all? do |item, row_idx|
+      idx == row_idx || row[idx] >= item
+    end
+  end
+
+  def smallest_in_column?(column, idx)
+    column.each_with_index.all? do |item, column_idx|
+      idx == column_idx || column[idx] <= item
+    end
+  end
+end

--- a/saddle-points/saddle_points_test.rb
+++ b/saddle-points/saddle_points_test.rb
@@ -1,0 +1,63 @@
+require 'minitest/autorun'
+require_relative 'saddle_points'
+
+class MatrixTest < Minitest::Test
+  def test_extract_a_row
+    matrix = Matrix.new("1 2\n10 20")
+    assert_equal [1, 2], matrix.rows[0]
+  end
+
+  def test_extract_same_row_again
+    # skip
+    matrix = Matrix.new("9 7\n8 6")
+    assert_equal [9, 7], matrix.rows[0]
+  end
+
+  def test_extract_other_row
+    # skip
+    matrix = Matrix.new("9 8 7\n19 18 17")
+    assert_equal [19, 18, 17], matrix.rows[1]
+  end
+
+  def test_extract_other_row_again
+    # skip
+    matrix = Matrix.new("1 4 9\n16 25 36")
+    assert_equal [16, 25, 36], matrix.rows[1]
+  end
+
+  def test_extract_a_column
+    # skip
+    matrix = Matrix.new("1 2 3\n4 5 6\n7 8 9\n 8 7 6")
+    assert_equal [1, 4, 7, 8], matrix.columns[0]
+  end
+
+  def test_extract_another_column
+    # skip
+    matrix = Matrix.new("89 1903 3\n18 3 1\n9 4 800")
+    assert_equal [1903, 3, 4], matrix.columns[1]
+  end
+
+  def test_no_saddle_point
+    # skip
+    matrix = Matrix.new("2 1\n1 2")
+    assert_equal [], matrix.saddle_points
+  end
+
+  def test_a_saddle_point
+    # skip
+    matrix = Matrix.new("1 2\n3 4")
+    assert_equal [[0, 1]], matrix.saddle_points
+  end
+
+  def test_another_saddle_point
+    # skip
+    matrix = Matrix.new("18 3 39 19 91\n38 10 8 77 320\n3 4 8 6 7")
+    assert_equal [[2, 2]], matrix.saddle_points
+  end
+
+  def test_multiple_saddle_points
+    # skip
+    matrix = Matrix.new("4 5 4\n3 5 5\n1 5 4")
+    assert_equal [[0, 1], [1, 1], [2, 1]], matrix.saddle_points
+  end
+end


### PR DESCRIPTION
# Saddle Points

Detect saddle points in a matrix.

So say you have a matrix like so:

```text
    0  1  2
  |---------
0 | 9  8  7
1 | 5  3  2     <--- saddle point at (1,0)
2 | 6  6  7
```

It has a saddle point at (1, 0).

It's called a "saddle point" because it is greater than or equal to
every element in its row and less than or equal to every element in
its column.

A matrix may have zero or more saddle points.

Your code should be able to provide the (possibly empty) list of all the
saddle points for any given matrix.

The matrix can have a different number of rows and columns (Non square).

Note that you may find other definitions of matrix saddle points online,
but the tests for this exercise follow the above unambiguous definition.

* * * *

For installation and learning resources, refer to the
[Ruby resources page](http://exercism.io/languages/ruby/resources).

For running the tests provided, you will need the Minitest gem. Open a
terminal window and run the following command to install minitest:

    gem install minitest

If you would like color output, you can `require 'minitest/pride'` in
the test file, or note the alternative instruction, below, for running
the test file.

Run the tests from the exercise directory using the following command:

    ruby saddle_points_test.rb

To include color from the command line:

    ruby -r minitest/pride saddle_points_test.rb


## Source

J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)

## Submitting Incomplete Solutions
It's possible to submit an incomplete solution so you can see how others have completed the exercise.
