### PR TITLE
Atbash cipher

### DIFF
--- a/atbash-cipher/.exercism/metadata.json
+++ b/atbash-cipher/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"atbash-cipher","id":"9e6bf3af46a8434c820ad212ca642d48","url":"https://exercism.io/my/solutions/9e6bf3af46a8434c820ad212ca642d48","handle":"de-farias","is_requester":true,"auto_approve":false}

--- a/atbash-cipher/README.md
+++ b/atbash-cipher/README.md
@@ -1,0 +1,59 @@
+# Atbash Cipher
+
+Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.
+
+The Atbash cipher is a simple substitution cipher that relies on
+transposing all the letters in the alphabet such that the resulting
+alphabet is backwards. The first letter is replaced with the last
+letter, the second with the second-last, and so on.
+
+An Atbash cipher for the Latin alphabet would be as follows:
+
+```text
+Plain:  abcdefghijklmnopqrstuvwxyz
+Cipher: zyxwvutsrqponmlkjihgfedcba
+```
+
+It is a very weak cipher because it only has one possible key, and it is
+a simple monoalphabetic substitution cipher. However, this may not have
+been an issue in the cipher's time.
+
+Ciphertext is written out in groups of fixed length, the traditional group size
+being 5 letters, and punctuation is excluded. This is to make it harder to guess
+things based on word boundaries.
+
+## Examples
+
+- Encoding `test` gives `gvhg`
+- Decoding `gvhg` gives `test`
+- Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby atbash_cipher_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride atbash_cipher_test.rb
+
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/Atbash](http://en.wikipedia.org/wiki/Atbash)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/atbash-cipher/atbash_cipher.rb
+++ b/atbash-cipher/atbash_cipher.rb
@@ -1,0 +1,16 @@
+class Atbash # :nodoc:
+  NUMBERS               = ('0'..'9').to_a
+  REGULAR_ALPHABET      = ('a'..'z').to_a
+  REGULAR_WITH_NUMBERS  = REGULAR_ALPHABET + NUMBERS
+  REVERSED_ALPHABET     = REGULAR_ALPHABET.reverse
+  REVERSED_WITH_NUMBERS = REVERSED_ALPHABET + NUMBERS
+  DICTIONARY            = Hash[REGULAR_WITH_NUMBERS.zip(REVERSED_WITH_NUMBERS)]
+
+  def self.encode(text)
+    crypted_chars = text.downcase.chars.map { |char| DICTIONARY[char] }.compact
+
+    crypted_chars.each_slice(5)
+                 .map(&:join)
+                 .join(' ')
+  end
+end

--- a/atbash-cipher/atbash_cipher.rb
+++ b/atbash-cipher/atbash_cipher.rb
@@ -1,16 +1,11 @@
 class Atbash # :nodoc:
-  NUMBERS               = ('0'..'9').to_a
-  REGULAR_ALPHABET      = ('a'..'z').to_a
-  REGULAR_WITH_NUMBERS  = REGULAR_ALPHABET + NUMBERS
+  REGULAR_ALPHABET      = Array('a'..'z').join
   REVERSED_ALPHABET     = REGULAR_ALPHABET.reverse
-  REVERSED_WITH_NUMBERS = REVERSED_ALPHABET + NUMBERS
-  DICTIONARY            = Hash[REGULAR_WITH_NUMBERS.zip(REVERSED_WITH_NUMBERS)]
 
   def self.encode(text)
-    crypted_chars = text.downcase.chars.map { |char| DICTIONARY[char] }.compact
-
-    crypted_chars.each_slice(5)
-                 .map(&:join)
+    cleansed_text = text.downcase.delete('^a-z0-9')
+    cleansed_text.tr(REGULAR_ALPHABET, REVERSED_ALPHABET)
+                 .scan(/\w{1,5}/)
                  .join(' ')
   end
 end

--- a/atbash-cipher/atbash_cipher_test.rb
+++ b/atbash-cipher/atbash_cipher_test.rb
@@ -1,0 +1,46 @@
+require 'minitest/autorun'
+require_relative 'atbash_cipher'
+
+class AtbashTest < Minitest::Test
+  def test_encode_no
+    assert_equal 'ml', Atbash.encode('no')
+  end
+
+  def test_encode_yes
+    # skip
+    assert_equal 'bvh', Atbash.encode('yes')
+  end
+
+  def test_encode_OMG
+    # skip
+    assert_equal 'lnt', Atbash.encode('OMG')
+  end
+
+  def test_encode_O_M_G
+    # skip
+    assert_equal 'lnt', Atbash.encode('O M G')
+  end
+
+  def test_encode_long_word
+    # skip
+    assert_equal 'nrmwy oldrm tob', Atbash.encode('mindblowingly')
+  end
+
+  def test_encode_numbers
+    # skip
+    assert_equal('gvhgr mt123 gvhgr mt',
+                 Atbash.encode('Testing, 1 2 3, testing.'))
+  end
+
+  def test_encode_sentence
+    # skip
+    assert_equal 'gifgs rhurx grlm', Atbash.encode('Truth is fiction.')
+  end
+
+  def test_encode_all_the_things
+    # skip
+    plaintext = 'The quick brown fox jumps over the lazy dog.'
+    cipher = 'gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt'
+    assert_equal cipher, Atbash.encode(plaintext)
+  end
+end


### PR DESCRIPTION
# Atbash Cipher

Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.

The Atbash cipher is a simple substitution cipher that relies on
transposing all the letters in the alphabet such that the resulting
alphabet is backwards. The first letter is replaced with the last
letter, the second with the second-last, and so on.

An Atbash cipher for the Latin alphabet would be as follows:

```text
Plain:  abcdefghijklmnopqrstuvwxyz
Cipher: zyxwvutsrqponmlkjihgfedcba
```

It is a very weak cipher because it only has one possible key, and it is
a simple monoalphabetic substitution cipher. However, this may not have
been an issue in the cipher's time.

Ciphertext is written out in groups of fixed length, the traditional group size
being 5 letters, and punctuation is excluded. This is to make it harder to guess
things based on word boundaries.

## Examples

- Encoding `test` gives `gvhg`
- Decoding `gvhg` gives `test`
- Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`

* * * *

For installation and learning resources, refer to the
[Ruby resources page](http://exercism.io/languages/ruby/resources).

For running the tests provided, you will need the Minitest gem. Open a
terminal window and run the following command to install minitest:

    gem install minitest

If you would like color output, you can `require 'minitest/pride'` in
the test file, or note the alternative instruction, below, for running
the test file.

Run the tests from the exercise directory using the following command:

    ruby atbash_cipher_test.rb

To include color from the command line:

    ruby -r minitest/pride atbash_cipher_test.rb


## Source

Wikipedia [http://en.wikipedia.org/wiki/Atbash](http://en.wikipedia.org/wiki/Atbash)

## Submitting Incomplete Solutions
It's possible to submit an incomplete solution so you can see how others have completed the exercise.
