### PR TITLE
Implements the List Ops exercise

### DIFF
--- a/list-ops/.exercism/metadata.json
+++ b/list-ops/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"list-ops","id":"ce8b19bf7c9145eaa0c779dfa7329179","url":"https://exercism.io/my/solutions/ce8b19bf7c9145eaa0c779dfa7329179","handle":"de-farias","is_requester":true,"auto_approve":false}

--- a/list-ops/README.md
+++ b/list-ops/README.md
@@ -1,0 +1,33 @@
+# List Ops
+
+Implement basic list operations.
+
+In functional languages list operations like `length`, `map`, and
+`reduce` are very common. Implement a series of basic list operations,
+without using existing functions.
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby list_ops_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride list_ops_test.rb
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/list-ops/list_ops.rb
+++ b/list-ops/list_ops.rb
@@ -1,0 +1,49 @@
+class ListOps
+  class << self
+    def arrays(input)
+      input.reduce(0) { |m, _| m + 1 }
+    end
+
+    def reverser(input)
+      [].tap do |reversed|
+        reversed << input.pop while input.any?
+      end
+    end
+
+    def concatter(input1, input2)
+      input1.tap do |concatted|
+        concatted << input2.shift while input2.any?
+      end
+    end
+
+    def mapper(input, &block)
+      [].tap do |mapped|
+        input.each do |item|
+          mapped << yield(item)
+        end
+      end
+    end
+
+    def filterer(input, &block)
+      [].tap do |mapped|
+        input.each do |item|
+          mapped << item if yield(item)
+        end
+      end
+    end
+
+    def sum_reducer(input)
+      sum = 0
+      input.each { |item| sum += item }
+
+      sum
+    end
+
+    def factorial_reducer(input)
+      product = 1
+      input.each { |item| product *= item }
+
+      product
+    end
+  end
+end

--- a/list-ops/list_ops_test.rb
+++ b/list-ops/list_ops_test.rb
@@ -1,0 +1,105 @@
+require 'minitest/autorun'
+require_relative 'list_ops'
+
+class ListOpsTest < Minitest::Test
+  def test_count_empty
+    assert_equal 0, ListOps.arrays([])
+  end
+
+  def test_count_normal
+    # skip
+    assert_equal 5, ListOps.arrays(Array.new(5))
+  end
+
+  def test_count_gigantic
+    # skip
+    assert_equal 1_000_000, ListOps.arrays(Array.new(1_000_000))
+  end
+
+  def test_reverse_empty
+    # skip
+    assert_equal [], ListOps.reverser([])
+  end
+
+  def test_reverse_normal
+    # skip
+    assert_equal [5, 4, 3, 2, 1], ListOps.reverser([1, 2, 3, 4, 5])
+  end
+
+  def test_reverse_gigantic
+    # skip
+    expected = (1..1_000_000).to_a.reverse
+    assert_equal expected, ListOps.reverser((1..1_000_000).to_a)
+  end
+
+  def test_concat_empty
+    # skip
+    assert_equal [], ListOps.concatter([], [])
+  end
+
+  def test_concat_normal
+    # skip
+    assert_equal [12, 34, 56, 78], ListOps.concatter([12, 34], [56, 78])
+  end
+
+  def test_concat_gigantic
+    # skip
+    input1 = (1..1_000_000).to_a
+    input2 = (1_000_001..2_000_000).to_a
+    assert_equal (1..2_000_000).to_a, ListOps.concatter(input1, input2)
+  end
+
+  def test_mapper_empty
+    # skip
+    assert_equal [], ListOps.mapper([])
+  end
+
+  def test_mapper_normal
+    # skip
+    assert_equal [2, 3, 4, 5, 6], ListOps.mapper([1, 2, 3, 4, 5]) { |n| n + 1 }
+  end
+
+  def test_mapper_gigantic
+    # skip
+    result = ListOps.mapper((1..1_000_000).to_a) { |n| n + 1 }
+    assert_equal (2..1_000_001).to_a, result
+  end
+
+  def test_filterer_empty
+    # skip
+    assert_equal [], ListOps.filterer([])
+  end
+
+  def test_filterer_normal
+    # skip
+    result = ListOps.filterer([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], &:odd?)
+    assert_equal [1, 3, 5, 7, 9], result
+  end
+
+  def test_filterer_gigantic
+    # skip
+    result = ListOps.filterer((1..10_000).to_a, &:even?)
+    assert_equal (1..10_000).to_a.select(&:even?), result
+  end
+
+  def test_sum_reducer_empty
+    # skip
+    assert_equal 0, ListOps.sum_reducer([])
+  end
+
+  def test_sum_reducer_normal
+    # skip
+    assert_equal 55, ListOps.sum_reducer([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  end
+
+  def test_factorial_reducer_empty
+    # skip
+    assert_equal 1, ListOps.factorial_reducer([])
+  end
+
+  def test_factorial_reducer_normal
+    # skip
+    input = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    assert_equal 3_628_800, ListOps.factorial_reducer(input)
+  end
+end


### PR DESCRIPTION
# List Ops

 Implement basic list operations.

 In functional languages list operations like `length`, `map`, and
`reduce` are very common. Implement a series of basic list operations,
without using existing functions.

 * * * *

 For installation and learning resources, refer to the
[Ruby resources page](http://exercism.io/languages/ruby/resources).

 For running the tests provided, you will need the Minitest gem. Open a
terminal window and run the following command to install minitest:

     gem install minitest

 If you would like color output, you can `require 'minitest/pride'` in
the test file, or note the alternative instruction, below, for running
the test file.

 Run the tests from the exercise directory using the following command:

     ruby list_ops_test.rb

 To include color from the command line:

     ruby -r minitest/pride list_ops_test.rb


 ## Submitting Incomplete Solutions
It's possible to submit an incomplete solution so you can see how others have completed the exercise.