### PR TITLE
Largest series product

### DIFF
--- a/largest-series-product/.exercism/metadata.json
+++ b/largest-series-product/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"largest-series-product","id":"e70e84c4f4d946b19607d3b51ade5ea6","url":"https://exercism.io/my/solutions/e70e84c4f4d946b19607d3b51ade5ea6","handle":"de-farias","is_requester":true,"auto_approve":false}

--- a/largest-series-product/README.md
+++ b/largest-series-product/README.md
@@ -1,0 +1,44 @@
+# Largest Series Product
+
+Given a string of digits, calculate the largest product for a contiguous
+substring of digits of length n.
+
+For example, for the input `'1027839564'`, the largest product for a
+series of 3 digits is 270 (9 * 5 * 6), and the largest product for a
+series of 5 digits is 7560 (7 * 8 * 3 * 9 * 5).
+
+Note that these series are only required to occupy *adjacent positions*
+in the input; the digits need not be *numerically consecutive*.
+
+For the input `'73167176531330624919225119674426574742355349194934'`,
+the largest product for a series of 6 digits is 23520.
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby largest_series_product_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride largest_series_product_test.rb
+
+
+## Source
+
+A variation on Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/largest-series-product/largest_series_product.rb
+++ b/largest-series-product/largest_series_product.rb
@@ -19,10 +19,8 @@ class Series # :nodoc:
   attr_reader :chars
 
   def validate_input!(sequence_length)
-    invalid_input = sequence_length > chars.length ||
-                    sequence_length < 0 ||
-                    chars.any? { |d| d =~ /\D/ }
-
-    raise ArgumentError if invalid_input
+    raise ArgumentError if sequence_length > chars.length ||
+                           sequence_length < 0 ||
+                           chars.any? { |d| d =~ /\D/ }
   end
 end

--- a/largest-series-product/largest_series_product.rb
+++ b/largest-series-product/largest_series_product.rb
@@ -1,0 +1,28 @@
+class Series # :nodoc:
+  def initialize(string)
+    @chars = string.chars
+  end
+
+  def largest_product(sequence_length)
+    validate_input!(sequence_length)
+
+    return 1 if chars.empty? || sequence_length.zero?
+
+    chars.map(&:to_i)
+         .each_cons(sequence_length)
+         .map { |seq| seq.inject(:*) }
+         .max
+  end
+
+  private
+
+  attr_reader :chars
+
+  def validate_input!(sequence_length)
+    invalid_input = sequence_length > chars.length ||
+                    sequence_length < 0 ||
+                    chars.any? { |d| d =~ /\D/ }
+
+    raise ArgumentError if invalid_input
+  end
+end

--- a/largest-series-product/largest_series_product.rb
+++ b/largest-series-product/largest_series_product.rb
@@ -19,8 +19,7 @@ class Series # :nodoc:
   attr_reader :chars
 
   def validate_input!(sequence_length)
-    raise ArgumentError if sequence_length > chars.length ||
-                           sequence_length < 0 ||
-                           chars.any? { |d| d =~ /\D/ }
+    raise ArgumentError unless sequence_length.between?(0, chars.length) &&
+                               chars.all? { |d| d =~ /\d/ }
   end
 end

--- a/largest-series-product/largest_series_product_test.rb
+++ b/largest-series-product/largest_series_product_test.rb
@@ -1,0 +1,88 @@
+require 'minitest/autorun'
+require_relative 'largest_series_product'
+
+# Common test data version: 1.2.0 85da7a5
+class LargestSeriesProductTest < Minitest::Test
+  def test_finds_the_largest_product_if_span_equals_length
+    # skip
+    assert_equal 18, Series.new('29').largest_product(2)
+  end
+
+  def test_can_find_the_largest_product_of_2_with_numbers_in_order
+    # skip
+    assert_equal 72, Series.new('0123456789').largest_product(2)
+  end
+
+  def test_can_find_the_largest_product_of_2
+    # skip
+    assert_equal 48, Series.new('576802143').largest_product(2)
+  end
+
+  def test_can_find_the_largest_product_of_3_with_numbers_in_order
+    # skip
+    assert_equal 504, Series.new('0123456789').largest_product(3)
+  end
+
+  def test_can_find_the_largest_product_of_3
+    # skip
+    assert_equal 270, Series.new('1027839564').largest_product(3)
+  end
+
+  def test_can_find_the_largest_product_of_5_with_numbers_in_order
+    # skip
+    assert_equal 15120, Series.new('0123456789').largest_product(5)
+  end
+
+  def test_can_get_the_largest_product_of_a_big_number
+    # skip
+    assert_equal 23520, Series.new('73167176531330624919225119674426574742355349194934').largest_product(6)
+  end
+
+  def test_reports_zero_if_the_only_digits_are_zero
+    # skip
+    assert_equal 0, Series.new('0000').largest_product(2)
+  end
+
+  def test_reports_zero_if_all_spans_include_zero
+    # skip
+    assert_equal 0, Series.new('99099').largest_product(3)
+  end
+
+  def test_rejects_span_longer_than_string_length
+    # skip
+    assert_raises(ArgumentError) do
+      Series.new('123').largest_product(4)
+    end
+  end
+
+  def test_reports_1_for_empty_string_and_empty_product_0_span
+    # skip
+    assert_equal 1, Series.new('').largest_product(0)
+  end
+
+  def test_reports_1_for_nonempty_string_and_empty_product_0_span
+    # skip
+    assert_equal 1, Series.new('123').largest_product(0)
+  end
+
+  def test_rejects_empty_string_and_nonzero_span
+    # skip
+    assert_raises(ArgumentError) do
+      Series.new('').largest_product(1)
+    end
+  end
+
+  def test_rejects_invalid_character_in_digits
+    # skip
+    assert_raises(ArgumentError) do
+      Series.new('1234a5').largest_product(2)
+    end
+  end
+
+  def test_rejects_negative_span
+    # skip
+    assert_raises(ArgumentError) do
+      Series.new('12345').largest_product(-1)
+    end
+  end
+end


### PR DESCRIPTION
# Largest Series Product

 Given a string of digits, calculate the largest product for a contiguous
substring of digits of length n.

 For example, for the input `'1027839564'`, the largest product for a
series of 3 digits is 270 (9 * 5 * 6), and the largest product for a
series of 5 digits is 7560 (7 * 8 * 3 * 9 * 5).

 Note that these series are only required to occupy *adjacent positions*
in the input; the digits need not be *numerically consecutive*.

 For the input `'73167176531330624919225119674426574742355349194934'`,
the largest product for a series of 6 digits is 23520.

 * * * *

 For installation and learning resources, refer to the
[Ruby resources page](http://exercism.io/languages/ruby/resources).

 For running the tests provided, you will need the Minitest gem. Open a
terminal window and run the following command to install minitest:

     gem install minitest

 If you would like color output, you can `require 'minitest/pride'` in
the test file, or note the alternative instruction, below, for running
the test file.

 Run the tests from the exercise directory using the following command:

     ruby largest_series_product_test.rb

 To include color from the command line:

     ruby -r minitest/pride largest_series_product_test.rb


 ## Source

 A variation on Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)

 ## Submitting Incomplete Solutions
It's possible to submit an incomplete solution so you can see how others have completed the exercise.