### PR TITLE
Implements the Pythagorean Triplet exercise

### DIFF
--- a/pythagorean-triplet/.exercism/metadata.json
+++ b/pythagorean-triplet/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"pythagorean-triplet","id":"9dc835dae6eb42099911490c8358468d","url":"https://exercism.io/my/solutions/9dc835dae6eb42099911490c8358468d","handle":"de-farias","is_requester":true,"auto_approve":false}

--- a/pythagorean-triplet/README.md
+++ b/pythagorean-triplet/README.md
@@ -1,0 +1,48 @@
+# Pythagorean Triplet
+
+A Pythagorean triplet is a set of three natural numbers, {a, b, c}, for
+which,
+
+```text
+a**2 + b**2 = c**2
+```
+
+For example,
+
+```text
+3**2 + 4**2 = 9 + 16 = 25 = 5**2.
+```
+
+There exists exactly one Pythagorean triplet for which a + b + c = 1000.
+
+Find the product a * b * c.
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby pythagorean_triplet_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride pythagorean_triplet_test.rb
+
+
+## Source
+
+Problem 9 at Project Euler [http://projecteuler.net/problem=9](http://projecteuler.net/problem=9)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/pythagorean-triplet/pythagorean_triplet.rb
+++ b/pythagorean-triplet/pythagorean_triplet.rb
@@ -1,0 +1,32 @@
+class Triplet # :nodoc:
+  def self.where(min_factor: 1, max_factor:, sum: :any)
+    triplets = (min_factor..max_factor).to_a.combination(3).map do |sides|
+      Triplet.new(*sides)
+    end
+    triplets.select!(&:pythagorean?)
+    triplets.select! { |t| t.sum == sum } unless sum == :any
+
+    triplets
+  end
+
+  def initialize(*sides)
+    @sides = sides
+  end
+
+  def sum
+    sides.sum
+  end
+
+  def product
+    sides.inject(:*)
+  end
+
+  def pythagorean?
+    a, b, c = sides
+    a**2 + b**2 == c**2
+  end
+
+  private
+
+  attr_reader :sides
+end

--- a/pythagorean-triplet/pythagorean_triplet_test.rb
+++ b/pythagorean-triplet/pythagorean_triplet_test.rb
@@ -1,0 +1,44 @@
+require 'minitest/autorun'
+require_relative 'pythagorean_triplet'
+
+class TripletTest < Minitest::Test
+  def test_sum
+    assert_equal 12, Triplet.new(3, 4, 5).sum
+  end
+
+  def test_product
+    # skip
+    assert_equal 60, Triplet.new(3, 4, 5).product
+  end
+
+  def test_pythagorean
+    # skip
+    assert Triplet.new(3, 4, 5).pythagorean?
+  end
+
+  def test_not_pythagorean
+    # skip
+    refute Triplet.new(5, 6, 7).pythagorean?
+  end
+
+  def test_triplets_upto_10
+    # skip
+    triplets = Triplet.where(max_factor: 10)
+    products = triplets.map(&:product).sort
+    assert_equal [60, 480], products
+  end
+
+  def test_triplets_from_11_upto_20
+    # skip
+    triplets = Triplet.where(min_factor: 11, max_factor: 20)
+    products = triplets.map(&:product).sort
+    assert_equal [3840], products
+  end
+
+  def test_triplets_where_sum_x
+    # skip
+    triplets = Triplet.where(sum: 180, max_factor: 100)
+    products = triplets.map(&:product).sort
+    assert_equal [118_080, 168_480, 202_500], products
+  end
+end


### PR DESCRIPTION
# Pythagorean Triplet

 A Pythagorean triplet is a set of three natural numbers, {a, b, c}, for
which,

 ```text
a**2 + b**2 = c**2
```

 For example,

 ```text
3**2 + 4**2 = 9 + 16 = 25 = 5**2.
```

 There exists exactly one Pythagorean triplet for which a + b + c = 1000.

 Find the product a * b * c.

 * * * *

 For installation and learning resources, refer to the
[Ruby resources page](http://exercism.io/languages/ruby/resources).

 For running the tests provided, you will need the Minitest gem. Open a
terminal window and run the following command to install minitest:

     gem install minitest

 If you would like color output, you can `require 'minitest/pride'` in
the test file, or note the alternative instruction, below, for running
the test file.

 Run the tests from the exercise directory using the following command:

     ruby pythagorean_triplet_test.rb

 To include color from the command line:

     ruby -r minitest/pride pythagorean_triplet_test.rb


 ## Source

 Problem 9 at Project Euler [http://projecteuler.net/problem=9](http://projecteuler.net/problem=9)

 ## Submitting Incomplete Solutions
It's possible to submit an incomplete solution so you can see how others have completed the exercise.
