### PR TITLE
Implements the Minesweeper exercise

### DIFF
--- a/minesweeper/.exercism/metadata.json
+++ b/minesweeper/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"minesweeper","id":"f902d3f2dc204697974db567447f0909","url":"https://exercism.io/my/solutions/f902d3f2dc204697974db567447f0909","handle":"de-farias","is_requester":true,"auto_approve":false}

--- a/minesweeper/README.md
+++ b/minesweeper/README.md
@@ -1,0 +1,53 @@
+# Minesweeper
+
+Add the numbers to a minesweeper board.
+
+Minesweeper is a popular game where the user has to find the mines using
+numeric hints that indicate how many mines are directly adjacent
+(horizontally, vertically, diagonally) to a square.
+
+In this exercise you have to create some code that counts the number of
+mines adjacent to a square and transforms boards like this (where `*`
+indicates a mine):
+
+    +-----+
+    | * * |
+    |  *  |
+    |  *  |
+    |     |
+    +-----+
+
+into this:
+
+    +-----+
+    |1*3*1|
+    |13*31|
+    | 2*2 |
+    | 111 |
+    +-----+
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby minesweeper_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride minesweeper_test.rb
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/minesweeper/board_validator.rb
+++ b/minesweeper/board_validator.rb
@@ -1,0 +1,53 @@
+class BoardValidator # :nodoc:
+  BOARD_HORIZONTAL_EDGE = '-'.freeze
+  BOARD_VERTICAL_EDGE   = '|'.freeze
+  BOARD_CORNER          = '+'.freeze
+  BOMB                  = '*'.freeze
+
+  def initialize(rows)
+    @rows = rows
+  end
+
+  def valid?
+    rows_with_same_length? && flawless_edges? && only_valid_chars?
+  end
+
+  private
+
+  attr_reader :rows
+
+  def rows_with_same_length?
+    rows.each_cons(2).all? { |row1, row2| row1.length == row2.length }
+  end
+
+  def flawless_edges?
+    flawless_horizontal_edges? && flawless_vertical_edges?
+  end
+
+  def flawless_horizontal_edges?
+    [rows[0], rows[-1]].all? do |row|
+      [row[0], row[-1]].all? { |cell| cell == BOARD_CORNER } &&
+        row[1...-1].all? { |cell| cell == BOARD_HORIZONTAL_EDGE }
+    end
+  end
+
+  def flawless_vertical_edges?
+    rows[1...-1].all? do |row|
+      [row[0], row[-1]].all? { |cell| cell == BOARD_VERTICAL_EDGE }
+    end
+  end
+
+  def only_valid_chars?
+    valid_chars = [
+      BOARD_HORIZONTAL_EDGE,
+      BOARD_VERTICAL_EDGE,
+      BOARD_CORNER,
+      BOMB,
+      ' '
+    ]
+
+    rows.all? do |row|
+      row.all? { |cell| valid_chars.include?(cell) }
+    end
+  end
+end

--- a/minesweeper/minesweeper.rb
+++ b/minesweeper/minesweeper.rb
@@ -1,0 +1,68 @@
+require_relative 'board_validator'
+
+class Board # :nodoc:
+  BOARD_OFFSET = 1
+  BOMB         = '*'.freeze
+
+  def self.transform(input)
+    new(input).transform
+  end
+
+  def initialize(rows)
+    rows_chars = rows.map(&:chars)
+    raise ArgumentError unless BoardValidator.new(rows_chars).valid?
+
+    @rows = rows_chars
+  end
+
+  def transform
+    rows[1...-1].each_with_index do |row, idx|
+      row_idx = idx + BOARD_OFFSET
+
+      row[1...-1].each_with_index do |_, inner_idx|
+        col_idx = inner_idx + BOARD_OFFSET
+
+        insert_bomb_count(row_idx, col_idx)
+      end
+    end
+
+    rows.map(&:join)
+  end
+
+  private
+
+  attr_reader :rows
+
+  def insert_bomb_count(row, col)
+    return if bomb?(row, col)
+
+    bomb_count     = count_near_bombs(row, col)
+    new_cell_value = bomb_count.zero? ? ' ' : bomb_count
+
+    rows[row][col] = new_cell_value
+  end
+
+  def count_near_bombs(row, col)
+    near_cells(row).product(near_cells(col)).count do |(row_idx, col_idx)|
+      bomb?(row_idx, col_idx) &&
+        !edge_row?(row_idx) &&
+        !edge_column?(col_idx)
+    end
+  end
+
+  def near_cells(idx)
+    ((idx - 1)..(idx + 1)).to_a
+  end
+
+  def edge_row?(row)
+    row.zero? || row == rows.length - 1
+  end
+
+  def edge_column?(col)
+    col.zero? || col == rows[0].length - 1
+  end
+
+  def bomb?(row, col)
+    rows[row][col] == BOMB
+  end
+end

--- a/minesweeper/minesweeper_test.rb
+++ b/minesweeper/minesweeper_test.rb
@@ -1,0 +1,176 @@
+require 'minitest/autorun'
+require_relative 'minesweeper'
+
+class MinesweeperTest < Minitest::Test
+  def test_transform1
+    inp = ['+------+',
+           '| *  * |',
+           '|  *   |',
+           '|    * |',
+           '|   * *|',
+           '| *  * |',
+           '|      |',
+           '+------+']
+    out = ['+------+',
+           '|1*22*1|',
+           '|12*322|',
+           '| 123*2|',
+           '|112*4*|',
+           '|1*22*2|',
+           '|111111|',
+           '+------+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_transform2
+    # skip
+    inp = ['+-----+',
+           '| * * |',
+           '|     |',
+           '|   * |',
+           '|  * *|',
+           '| * * |',
+           '+-----+']
+    out = ['+-----+',
+           '|1*2*1|',
+           '|11322|',
+           '| 12*2|',
+           '|12*4*|',
+           '|1*3*2|',
+           '+-----+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_transform3
+    # skip
+    inp = ['+-----+',
+           '| * * |',
+           '+-----+']
+    out = ['+-----+',
+           '|1*2*1|',
+           '+-----+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_transform4
+    # skip
+    inp = ['+-+',
+           '|*|',
+           '| |',
+           '|*|',
+           '| |',
+           '| |',
+           '+-+']
+    out = ['+-+',
+           '|*|',
+           '|2|',
+           '|*|',
+           '|1|',
+           '| |',
+           '+-+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_transform5
+    # skip
+    inp = ['+-+',
+           '|*|',
+           '+-+']
+    out = ['+-+',
+           '|*|',
+           '+-+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_transform6
+    # skip
+    inp = ['+--+',
+           '|**|',
+           '|**|',
+           '+--+']
+    out = ['+--+',
+           '|**|',
+           '|**|',
+           '+--+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_transform7
+    # skip
+    inp = ['+--+',
+           '|**|',
+           '|**|',
+           '+--+']
+    out = ['+--+',
+           '|**|',
+           '|**|',
+           '+--+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_transform8
+    # skip
+    inp = ['+---+',
+           '|***|',
+           '|* *|',
+           '|***|',
+           '+---+']
+    out = ['+---+',
+           '|***|',
+           '|*8*|',
+           '|***|',
+           '+---+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_transform9
+    # skip
+    inp = ['+-----+',
+           '|     |',
+           '|   * |',
+           '|     |',
+           '|     |',
+           '| *   |',
+           '+-----+']
+    out = ['+-----+',
+           '|  111|',
+           '|  1*1|',
+           '|  111|',
+           '|111  |',
+           '|1*1  |',
+           '+-----+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_different_len
+    # skip
+    inp = ['+-+',
+           '| |',
+           '|*  |',
+           '|  |',
+           '+-+']
+    assert_raises(ArgumentError) do
+      Board.transform(inp)
+    end
+  end
+
+  def test_faulty_border
+    # skip
+    inp = ['+-----+',
+           '*   * |',
+           '+-- --+']
+    assert_raises(ArgumentError) do
+      Board.transform(inp)
+    end
+  end
+
+  def test_invalid_char
+    # skip
+    inp = ['+-----+',
+           '|X  * |',
+           '+-----+']
+    assert_raises(ArgumentError) do
+      Board.transform(inp)
+    end
+  end
+end


### PR DESCRIPTION
# Minesweeper

 Add the numbers to a minesweeper board.

 Minesweeper is a popular game where the user has to find the mines using
numeric hints that indicate how many mines are directly adjacent
(horizontally, vertically, diagonally) to a square.

 In this exercise you have to create some code that counts the number of
mines adjacent to a square and transforms boards like this (where `*`
indicates a mine):

     +-----+
    | * * |
    |  *  |
    |  *  |
    |     |
    +-----+

 into this:

     +-----+
    |1*3*1|
    |13*31|
    | 2*2 |
    | 111 |
    +-----+

 * * * *

 For installation and learning resources, refer to the
[Ruby resources page](http://exercism.io/languages/ruby/resources).

 For running the tests provided, you will need the Minitest gem. Open a
terminal window and run the following command to install minitest:

     gem install minitest

 If you would like color output, you can `require 'minitest/pride'` in
the test file, or note the alternative instruction, below, for running
the test file.

 Run the tests from the exercise directory using the following command:

     ruby minesweeper_test.rb

 To include color from the command line:

     ruby -r minitest/pride minesweeper_test.rb


 ## Submitting Incomplete Solutions
It's possible to submit an incomplete solution so you can see how others have completed the exercise.
