### PR TITLE
Implements the OCR Numbers exercise

### DIFF
--- a/ocr-numbers/.exercism/metadata.json
+++ b/ocr-numbers/.exercism/metadata.json
@@ -1,0 +1,1 @@
+{"track":"ruby","exercise":"ocr-numbers","id":"75174500868244e8ab3008e6b66dac80","url":"https://exercism.io/my/solutions/75174500868244e8ab3008e6b66dac80","handle":"de-farias","is_requester":true,"auto_approve":false}

--- a/ocr-numbers/README.md
+++ b/ocr-numbers/README.md
@@ -1,0 +1,109 @@
+# OCR Numbers
+
+Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is
+represented, or whether it is garbled.
+
+# Step One
+
+To begin with, convert a simple binary font to a string containing 0 or 1.
+
+The binary font uses pipes and underscores, four rows high and three columns wide.
+
+```text
+     _   #
+    | |  # zero.
+    |_|  #
+         # the fourth row is always blank
+```
+
+Is converted to "0"
+
+```text
+         #
+      |  # one.
+      |  #
+         # (blank fourth row)
+```
+
+Is converted to "1"
+
+If the input is the correct size, but not recognizable, your program should return '?'
+
+If the input is the incorrect size, your program should return an error.
+
+# Step Two
+
+Update your program to recognize multi-character binary strings, replacing garbled numbers with ?
+
+# Step Three
+
+Update your program to recognize all numbers 0 through 9, both individually and as part of a larger string.
+
+```text
+ _ 
+ _|
+|_ 
+   
+```
+
+Is converted to "2"
+
+```text
+      _  _     _  _  _  _  _  _  #
+    | _| _||_||_ |_   ||_||_|| | # decimal numbers.
+    ||_  _|  | _||_|  ||_| _||_| #
+                                 # fourth line is always blank
+```
+
+Is converted to "1234567890"
+
+# Step Four
+
+Update your program to handle multiple numbers, one per line. When converting several lines, join the lines with commas.
+
+```text
+    _  _ 
+  | _| _|
+  ||_  _|
+         
+    _  _ 
+|_||_ |_ 
+  | _||_|
+         
+ _  _  _ 
+  ||_||_|
+  ||_| _|
+         
+```
+
+Is converted to "123,456,789"
+
+* * * *
+
+For installation and learning resources, refer to the
+[Ruby resources page](http://exercism.io/languages/ruby/resources).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby ocr_numbers_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride ocr_numbers_test.rb
+
+
+## Source
+
+Inspired by the Bank OCR kata [http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR](http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/ocr-numbers/ocr_numbers.rb
+++ b/ocr-numbers/ocr_numbers.rb
@@ -1,0 +1,70 @@
+class OcrNumbers # :nodoc:
+  ZERO  = ' _ | ||_|   '.freeze
+  ONE   = '     |  |   '.freeze
+  TWO   = ' _  _||_    '.freeze
+  THREE = ' _  _| _|   '.freeze
+  FOUR  = '   |_|  |   '.freeze
+  FIVE  = ' _ |_  _|   '.freeze
+  SIX   = ' _ |_ |_|   '.freeze
+  SEVEN = ' _   |  |   '.freeze
+  EIGHT = ' _ |_||_|   '.freeze
+  NINE  = ' _ |_| _|   '.freeze
+  DICTIONARY = Hash.new('?').merge(
+    ZERO  => '0',
+    ONE   => '1',
+    TWO   => '2',
+    THREE => '3',
+    FOUR  => '4',
+    FIVE  => '5',
+    SIX   => '6',
+    SEVEN => '7',
+    EIGHT => '8',
+    NINE  => '9'
+  ).freeze
+
+  class << self
+    def convert(input)
+      number_groups = parse(input)
+      number_groups.map do |number_group|
+        number_group.map { |code| DICTIONARY[code] }.join
+      end.join(',')
+    end
+
+    private
+
+    def parse(input)
+      lines = input.split("\n")
+      raise ArgumentError if wrong_number_of_lines?(lines) ||
+                             wrong_number_of_columns?(lines)
+
+      lines.each_slice(4).map { |group| numbers_from(group) }
+    end
+
+    def numbers_from(lines)
+      numbers = Array.new(numbers_count(lines)) { [] }
+
+      lines.each do |line|
+        line.chars.each_slice(3).each_with_index do |slice, idx|
+          numbers[idx].concat slice
+        end
+      end
+
+      numbers.map(&:join)
+    end
+
+    def wrong_number_of_lines?(lines)
+      lines.length % 4 != 0
+    end
+
+    def wrong_number_of_columns?(lines)
+      lines.any? { |line| line.length % 3 != 0 }
+    end
+
+    def numbers_count(lines)
+      lines_count      = lines.length / 4
+      numbers_per_line = lines[0].length / 3
+
+      lines_count * numbers_per_line
+    end
+  end
+end

--- a/ocr-numbers/ocr_numbers_test.rb
+++ b/ocr-numbers/ocr_numbers_test.rb
@@ -1,0 +1,169 @@
+require 'minitest/autorun'
+require_relative 'ocr_numbers'
+
+# Common test data version: 1.2.0 965ecad
+class OcrNumbersTest < Minitest::Test
+  def test_recognizes_0
+    # skip
+    input = [" _ ",
+             "| |",
+             "|_|",
+             "   "].join("\n")
+    assert_equal "0", OcrNumbers.convert(input)
+  end
+
+  def test_recognizes_1
+    # skip
+    input = ["   ",
+             "  |",
+             "  |",
+             "   "].join("\n")
+    assert_equal "1", OcrNumbers.convert(input)
+  end
+
+  def test_unreadable_but_correctly_sized_inputs_return_question_mark
+    # skip
+    input = ["   ",
+             "  _",
+             "  |",
+             "   "].join("\n")
+    assert_equal "?", OcrNumbers.convert(input)
+  end
+
+  def test_input_with_a_number_of_lines_that_is_not_a_multiple_of_four_raises_an_error
+    # skip
+    input = [" _ ",
+             "| |",
+             "   "].join("\n")
+    assert_raises(ArgumentError) do
+      OcrNumbers.convert(input)
+    end
+  end
+
+  def test_input_with_a_number_of_columns_that_is_not_a_multiple_of_three_raises_an_error
+    # skip
+    input = ["    ",
+             "   |",
+             "   |",
+             "    "].join("\n")
+    assert_raises(ArgumentError) do
+      OcrNumbers.convert(input)
+    end
+  end
+
+  def test_recognizes_110101100
+    # skip
+    input = ["       _     _        _  _ ",
+             "  |  || |  || |  |  || || |",
+             "  |  ||_|  ||_|  |  ||_||_|",
+             "                           "].join("\n")
+    assert_equal "110101100", OcrNumbers.convert(input)
+  end
+
+  def test_garbled_numbers_in_a_string_are_replaced_with_question_mark
+    # skip
+    input = ["       _     _           _ ",
+             "  |  || |  || |     || || |",
+             "  |  | _|  ||_|  |  ||_||_|",
+             "                           "].join("\n")
+    assert_equal "11?10?1?0", OcrNumbers.convert(input)
+  end
+
+  def test_recognizes_2
+    # skip
+    input = [" _ ",
+             " _|",
+             "|_ ",
+             "   "].join("\n")
+    assert_equal "2", OcrNumbers.convert(input)
+  end
+
+  def test_recognizes_3
+    # skip
+    input = [" _ ",
+             " _|",
+             " _|",
+             "   "].join("\n")
+    assert_equal "3", OcrNumbers.convert(input)
+  end
+
+  def test_recognizes_4
+    # skip
+    input = ["   ",
+             "|_|",
+             "  |",
+             "   "].join("\n")
+    assert_equal "4", OcrNumbers.convert(input)
+  end
+
+  def test_recognizes_5
+    # skip
+    input = [" _ ",
+             "|_ ",
+             " _|",
+             "   "].join("\n")
+    assert_equal "5", OcrNumbers.convert(input)
+  end
+
+  def test_recognizes_6
+    # skip
+    input = [" _ ",
+             "|_ ",
+             "|_|",
+             "   "].join("\n")
+    assert_equal "6", OcrNumbers.convert(input)
+  end
+
+  def test_recognizes_7
+    # skip
+    input = [" _ ",
+             "  |",
+             "  |",
+             "   "].join("\n")
+    assert_equal "7", OcrNumbers.convert(input)
+  end
+
+  def test_recognizes_8
+    # skip
+    input = [" _ ",
+             "|_|",
+             "|_|",
+             "   "].join("\n")
+    assert_equal "8", OcrNumbers.convert(input)
+  end
+
+  def test_recognizes_9
+    # skip
+    input = [" _ ",
+             "|_|",
+             " _|",
+             "   "].join("\n")
+    assert_equal "9", OcrNumbers.convert(input)
+  end
+
+  def test_recognizes_string_of_decimal_numbers
+    # skip
+    input = ["    _  _     _  _  _  _  _  _ ",
+             "  | _| _||_||_ |_   ||_||_|| |",
+             "  ||_  _|  | _||_|  ||_| _||_|",
+             "                              "].join("\n")
+    assert_equal "1234567890", OcrNumbers.convert(input)
+  end
+
+  def test_numbers_separated_by_empty_lines_are_recognized_lines_are_joined_by_commas
+    # skip
+    input = ["    _  _ ",
+             "  | _| _|",
+             "  ||_  _|",
+             "         ",
+             "    _  _ ",
+             "|_||_ |_ ",
+             "  | _||_|",
+             "         ",
+             " _  _  _ ",
+             "  ||_||_|",
+             "  ||_| _|",
+             "         "].join("\n")
+    assert_equal "123,456,789", OcrNumbers.convert(input)
+  end
+end


### PR DESCRIPTION
# OCR Numbers

Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is
represented, or whether it is garbled.

# Step One

To begin with, convert a simple binary font to a string containing 0 or 1.

The binary font uses pipes and underscores, four rows high and three columns wide.

```text
     _   #
    | |  # zero.
    |_|  #
         # the fourth row is always blank
```

Is converted to "0"

```text
         #
      |  # one.
      |  #
         # (blank fourth row)
```

Is converted to "1"

If the input is the correct size, but not recognizable, your program should return '?'

If the input is the incorrect size, your program should return an error.

# Step Two

Update your program to recognize multi-character binary strings, replacing garbled numbers with ?

# Step Three

Update your program to recognize all numbers 0 through 9, both individually and as part of a larger string.

```text
 _ 
 _|
|_ 
   
```

Is converted to "2"

```text
      _  _     _  _  _  _  _  _  #
    | _| _||_||_ |_   ||_||_|| | # decimal numbers.
    ||_  _|  | _||_|  ||_| _||_| #
                                 # fourth line is always blank
```

Is converted to "1234567890"

# Step Four

Update your program to handle multiple numbers, one per line. When converting several lines, join the lines with commas.

```text
    _  _ 
  | _| _|
  ||_  _|
         
    _  _ 
|_||_ |_ 
  | _||_|
         
 _  _  _ 
  ||_||_|
  ||_| _|
         
```

Is converted to "123,456,789"

* * * *

For installation and learning resources, refer to the
[Ruby resources page](http://exercism.io/languages/ruby/resources).

For running the tests provided, you will need the Minitest gem. Open a
terminal window and run the following command to install minitest:

    gem install minitest

If you would like color output, you can `require 'minitest/pride'` in
the test file, or note the alternative instruction, below, for running
the test file.

Run the tests from the exercise directory using the following command:

    ruby ocr_numbers_test.rb

To include color from the command line:

    ruby -r minitest/pride ocr_numbers_test.rb


## Source

Inspired by the Bank OCR kata [http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR](http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR)

## Submitting Incomplete Solutions
It's possible to submit an incomplete solution so you can see how others have completed the exercise.
